### PR TITLE
화면 좌표로 가게 재검색 API 구현

### DIFF
--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -39,6 +39,24 @@ public class StoreController {
         return ResponseEntity.ok().body(this.storeUseCase.getList(district, page));
     }
 
+    @Operation(description = "이 지역 재검색")
+    @GetMapping("/reload")
+    public ResponseEntity<List<StoreResponse>> reload(
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
+            @RequestParam(value = "southwestLatitude", required = true) Double southwestLatitude,
+            @RequestParam(value = "southwestLongitude", required = true) Double southwestLongitude,
+            @RequestParam(value = "northeastLatitude", required = true) Double northeastLatitude,
+            @RequestParam(value = "northeastLongitude", required = true) Double northeastLongitude
+    ) {
+        return ResponseEntity.ok().body(
+                this.storeUseCase.reload(
+                        page,
+                        southwestLatitude, southwestLongitude,
+                        northeastLatitude, northeastLongitude
+                )
+        );
+    }
+
     @Operation(description = "케이크샵 상세 정보 조회(상세 정보만)")
     @GetMapping("/{id}")
     public ResponseEntity<StoreDetailResponse> getStoreDetail(@PathVariable("id") Long storeId) {

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreExceptionController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreExceptionController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import prography.cakeke.server.store.exceptions.NotAllowedLocationException;
 import prography.cakeke.server.store.exceptions.NotFoundStoreException;
 
 @RestControllerAdvice
@@ -13,6 +14,11 @@ public class StoreExceptionController {
     @ExceptionHandler(value = NotFoundStoreException.class)
     protected ResponseEntity<String> notFoundStoreException(NotFoundStoreException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exception.getMessage());
+    }
+
+    @ExceptionHandler(value = NotAllowedLocationException.class)
+    protected ResponseEntity<String> notAllowedLocationException(NotAllowedLocationException exception) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(exception.getMessage());
     }
 
 }

--- a/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
@@ -14,6 +14,12 @@ public interface StoreUseCase {
 
     List<StoreResponse> getList(List<District> district, int page);
 
+    List<StoreResponse> reload(
+            int page,
+            Double southwestLatitude, Double southwestLongitude,
+            Double northeastLatitude, Double northeastLongitude
+    );
+
     StoreDetailResponse getStoreDetail(Long storeId);
 
     StoreBlogResponse getStoreBlog(Long storeId, Integer blogNum);

--- a/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
@@ -14,7 +14,11 @@ import prography.cakeke.server.store.domain.Store;
 public interface LoadStorePort {
     List<DistrictCountResponse> getDistrictCount();
 
-    List<StoreResponse> getList(List<District> district, Pageable pageable);
+    List<StoreResponse> getList(
+            List<District> district, Pageable pageable,
+            Double southwestLongitude, Double northeastLongitude,
+            Double southwestLatitude, Double northeastLatitude
+    );
 
     Map<Long, StoreResponse> getStoreDetail(Long storeId);
 

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -25,6 +25,11 @@ import prography.cakeke.server.store.exceptions.NotFoundStoreException;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StoreService implements StoreUseCase {
+    private static final Integer PAGE_SIZE = 100;   // 한 페이지당 사이즈
+    private static final Double SEOUL_SOUTHWEST_LATITUDE = 37.4289;   // 남서쪽 위도
+    private static final Double SEOUL_SOUTHWEST_LONGITUDE = 126.7649;     // 남서쪽 경도
+    private static final Double SEOUL_NORTHEAST_LATITUDE = 37.7010;     // 북동쪽 위도
+    private static final Double SEOUL_NORTHEAST_LONGITUDE = 127.1839;    // 북동쪽 경도
 
     private final LoadNaverSearchApiPort loadNaverSearchApiPort;
     private final LoadStorePort loadStorePort;
@@ -47,7 +52,7 @@ public class StoreService implements StoreUseCase {
     @Override
     public List<StoreResponse> getList(List<District> district, int page) {
         // southwestLatitude, southwestLongitude, northeastLatitude, northeastLongitude는 null
-        return loadStorePort.getList(district, PageRequest.of(page - 1, 100), null, null, null, null);
+        return loadStorePort.getList(district, PageRequest.of(page - 1, PAGE_SIZE), null, null, null, null);
     }
 
     /**
@@ -66,16 +71,16 @@ public class StoreService implements StoreUseCase {
             Double northeastLatitude, Double northeastLongitude
     ) {
         // 서울시 외곽의 서비스 불가 지역 체크
-        if (northeastLatitude < 37.4289 || southwestLatitude > 37.7010) {
+        if (northeastLatitude < SEOUL_SOUTHWEST_LATITUDE || southwestLatitude > SEOUL_NORTHEAST_LATITUDE) {
             throw new NotAllowedLocationException();
         }
-        if (northeastLongitude < 126.7649 || southwestLongitude > 127.1839) {
+        if (northeastLongitude < SEOUL_SOUTHWEST_LONGITUDE || southwestLongitude > SEOUL_NORTHEAST_LONGITUDE) {
             throw new NotAllowedLocationException();
         }
 
         // district는 null
         return loadStorePort.getList(
-                null, PageRequest.of(page - 1, 100),
+                null, PageRequest.of(page - 1, PAGE_SIZE),
                 southwestLatitude, southwestLongitude,
                 northeastLatitude, northeastLongitude
         );

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -18,6 +18,7 @@ import prography.cakeke.server.store.application.port.out.LoadNaverSearchApiPort
 import prography.cakeke.server.store.application.port.out.LoadStorePort;
 import prography.cakeke.server.store.domain.District;
 import prography.cakeke.server.store.domain.Store;
+import prography.cakeke.server.store.exceptions.NotAllowedLocationException;
 import prography.cakeke.server.store.exceptions.NotFoundStoreException;
 
 @Service
@@ -45,6 +46,7 @@ public class StoreService implements StoreUseCase {
      */
     @Override
     public List<StoreResponse> getList(List<District> district, int page) {
+        // southwestLatitude, southwestLongitude, northeastLatitude, northeastLongitude는 null
         return loadStorePort.getList(district, PageRequest.of(page - 1, 100), null, null, null, null);
     }
 
@@ -63,6 +65,15 @@ public class StoreService implements StoreUseCase {
             Double southwestLatitude, Double southwestLongitude,
             Double northeastLatitude, Double northeastLongitude
     ) {
+        // 서울시 외곽의 서비스 불가 지역 체크
+        if (northeastLatitude < 37.4289 || southwestLatitude > 37.7010) {
+            throw new NotAllowedLocationException();
+        }
+        if (northeastLongitude < 126.7649 || southwestLongitude > 127.1839) {
+            throw new NotAllowedLocationException();
+        }
+
+        // district는 null
         return loadStorePort.getList(
                 null, PageRequest.of(page - 1, 100),
                 southwestLatitude, southwestLongitude,

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -45,7 +45,29 @@ public class StoreService implements StoreUseCase {
      */
     @Override
     public List<StoreResponse> getList(List<District> district, int page) {
-        return loadStorePort.getList(district, PageRequest.of(page - 1, 15));
+        return loadStorePort.getList(district, PageRequest.of(page - 1, 100), null, null, null, null);
+    }
+
+    /**
+     * 현재 화면의 남서쪽 위도, 경도, 북동쪽 위도, 경도를 받아 해당하는 가게 리스트를 반환합니다.
+     * @param page 페이지 번호
+     * @param southwestLatitude 남서쪽 위도
+     * @param southwestLongitude 남서쪽 경도
+     * @param northeastLatitude 북동쪽 위도
+     * @param northeastLongitude 북동쪽 경도
+     * @return 가게 리스트
+     */
+    @Override
+    public List<StoreResponse> reload(
+            int page,
+            Double southwestLatitude, Double southwestLongitude,
+            Double northeastLatitude, Double northeastLongitude
+    ) {
+        return loadStorePort.getList(
+                null, PageRequest.of(page - 1, 100),
+                southwestLatitude, southwestLongitude,
+                northeastLatitude, northeastLongitude
+        );
     }
 
     /**

--- a/src/main/java/prography/cakeke/server/store/domain/Store.java
+++ b/src/main/java/prography/cakeke/server/store/domain/Store.java
@@ -3,6 +3,8 @@ package prography.cakeke.server.store.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.hibernate.annotations.BatchSize;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
@@ -51,6 +53,7 @@ public class Store extends Core {
     @Column(nullable = true)
     private String thumbnail;
 
+    @BatchSize(size = 100)
     @ElementCollection(fetch = FetchType.LAZY)
     private List<String> imageUrls;
 

--- a/src/main/java/prography/cakeke/server/store/exceptions/NotAllowedLocationException.java
+++ b/src/main/java/prography/cakeke/server/store/exceptions/NotAllowedLocationException.java
@@ -1,0 +1,7 @@
+package prography.cakeke.server.store.exceptions;
+
+public class NotAllowedLocationException extends RuntimeException {
+    public NotAllowedLocationException() {
+        super("서비스 불가한 지역입니다.");
+    }
+}


### PR DESCRIPTION
### Feature/store
- 좌표 내 케이크샵 조회 api 구현
- 서울시(서비스 제공 지역)를 벗어나서 좌표 내 케이크샵 재검색 시, 에러처리