### PR TITLE
refactor(image): image service 종속성 분리 #42

### DIFF
--- a/src/main/java/prography/cakeke/server/image/adaper/out/AwsS3Adapter.java
+++ b/src/main/java/prography/cakeke/server/image/adaper/out/AwsS3Adapter.java
@@ -1,0 +1,63 @@
+package prography.cakeke.server.image.adaper.out;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import lombok.RequiredArgsConstructor;
+import prography.cakeke.server.image.exceptions.InvalidFileNameException;
+import prography.cakeke.server.store.application.port.out.LoadS3Port;
+
+@Component
+@RequiredArgsConstructor
+public class AwsS3Adapter implements LoadS3Port {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.store-dir}")
+    private String dirName;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.base-url}")
+    private String baseUrl;
+
+    /** S3에 이미지 업로드 */
+    public String uploadS3(MultipartFile file) {
+        String fileName = dirName + createFileName(file.getOriginalFilename());
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                                       .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.");
+        }
+        return baseUrl + fileName;
+    }
+
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    private String getFileExtension(String fileName) {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            throw new InvalidFileNameException();
+        }
+    }
+}

--- a/src/main/java/prography/cakeke/server/image/adaper/out/AwsS3Adapter.java
+++ b/src/main/java/prography/cakeke/server/image/adaper/out/AwsS3Adapter.java
@@ -17,11 +17,11 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 
 import lombok.RequiredArgsConstructor;
 import prography.cakeke.server.image.exceptions.InvalidFileNameException;
-import prography.cakeke.server.store.application.port.out.LoadS3Port;
+import prography.cakeke.server.store.application.port.out.UploadS3Port;
 
 @Component
 @RequiredArgsConstructor
-public class AwsS3Adapter implements LoadS3Port {
+public class AwsS3Adapter implements UploadS3Port {
 
     private final AmazonS3 amazonS3;
 

--- a/src/main/java/prography/cakeke/server/image/application/service/ImageService.java
+++ b/src/main/java/prography/cakeke/server/image/application/service/ImageService.java
@@ -1,28 +1,17 @@
 package prography.cakeke.server.image.application.service;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
-
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.CannedAccessControlList;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import com.amazonaws.services.s3.model.PutObjectRequest;
 
 import lombok.RequiredArgsConstructor;
 import prography.cakeke.server.image.application.port.in.ImageUseCase;
-import prography.cakeke.server.image.exceptions.InvalidFileNameException;
 import prography.cakeke.server.image.exceptions.NotSupportedFileFormatException;
+import prography.cakeke.server.store.application.port.out.LoadS3Port;
 
 @Service
 @RequiredArgsConstructor
@@ -35,16 +24,7 @@ public class ImageService implements ImageUseCase {
             "image/jpg"
     );
 
-    private final AmazonS3 amazonS3;
-
-    @Value("${cloud.aws.s3.store-dir}")
-    private String dirName;
-
-    @Value("${cloud.aws.s3.base-url}")
-    private String baseUrl;
-
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
+    private final LoadS3Port loadS3Port;
 
     /**
      * 이미지들을 s3에 업로드합니다.
@@ -56,17 +36,8 @@ public class ImageService implements ImageUseCase {
 
         multipartFiles.forEach(file -> {
             mimeValidation(file.getContentType());
-            String fileName = dirName + createFileName(file.getOriginalFilename());
-            ObjectMetadata objectMetadata = new ObjectMetadata();
-            objectMetadata.setContentLength(file.getSize());
-            objectMetadata.setContentType(file.getContentType());
-            try (InputStream inputStream = file.getInputStream()) {
-                amazonS3.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
-                                           .withCannedAcl(CannedAccessControlList.PublicRead));
-            } catch (IOException e) {
-                throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 업로드에 실패했습니다.");
-            }
-            fileNameList.add(baseUrl + fileName);
+            String fileLink = loadS3Port.uploadS3(file);
+            fileNameList.add(fileLink);
         });
         return fileNameList;
     }
@@ -74,18 +45,6 @@ public class ImageService implements ImageUseCase {
     private void mimeValidation(String mime) {
         if (!FILETYPE.contains(mime)) {
             throw new NotSupportedFileFormatException(mime);
-        }
-    }
-
-    private String createFileName(String fileName) {
-        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
-    }
-
-    private String getFileExtension(String fileName) {
-        try {
-            return fileName.substring(fileName.lastIndexOf("."));
-        } catch (StringIndexOutOfBoundsException e) {
-            throw new InvalidFileNameException();
         }
     }
 }

--- a/src/main/java/prography/cakeke/server/image/application/service/ImageService.java
+++ b/src/main/java/prography/cakeke/server/image/application/service/ImageService.java
@@ -11,7 +11,7 @@ import org.springframework.web.multipart.MultipartFile;
 import lombok.RequiredArgsConstructor;
 import prography.cakeke.server.image.application.port.in.ImageUseCase;
 import prography.cakeke.server.image.exceptions.NotSupportedFileFormatException;
-import prography.cakeke.server.store.application.port.out.LoadS3Port;
+import prography.cakeke.server.store.application.port.out.UploadS3Port;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +24,7 @@ public class ImageService implements ImageUseCase {
             "image/jpg"
     );
 
-    private final LoadS3Port loadS3Port;
+    private final UploadS3Port uploadS3Port;
 
     /**
      * 이미지들을 s3에 업로드합니다.
@@ -36,7 +36,7 @@ public class ImageService implements ImageUseCase {
 
         multipartFiles.forEach(file -> {
             mimeValidation(file.getContentType());
-            String fileLink = loadS3Port.uploadS3(file);
+            String fileLink = uploadS3Port.uploadS3(file);
             fileNameList.add(fileLink);
         });
         return fileNameList;

--- a/src/main/java/prography/cakeke/server/store/application/port/out/LoadS3Port.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/out/LoadS3Port.java
@@ -1,0 +1,7 @@
+package prography.cakeke.server.store.application.port.out;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface LoadS3Port {
+    String uploadS3(MultipartFile file);
+}

--- a/src/main/java/prography/cakeke/server/store/application/port/out/UploadS3Port.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/out/UploadS3Port.java
@@ -2,6 +2,6 @@ package prography.cakeke.server.store.application.port.out;
 
 import org.springframework.web.multipart.MultipartFile;
 
-public interface LoadS3Port {
+public interface UploadS3Port {
     String uploadS3(MultipartFile file);
 }


### PR DESCRIPTION
## Test/test-store-id
- image service의 uploadImage 메서드 속 S3와 관련되 부분을 image adapter로 분리했어요. (외부 종속성을 분리시키는 헥사고날 아키텍쳐를 적용했기 때문)

## 기타
- 분리 후 테스트 완료.