### PR TITLE
store 서비스 new 코드 컨트롤러로 이동

### DIFF
--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -118,6 +118,7 @@ public class StoreController {
     public ResponseEntity<StoreBlogResponse> getStoreBlog(
             @PathVariable(value = "id") Long storeId,
             @RequestParam(value = "num", required = false, defaultValue = "3") Integer blogNum) {
-        return ResponseEntity.ok().body(this.storeUseCase.getStoreBlog(storeId, blogNum));
+        return ResponseEntity.ok().body(
+                new StoreBlogResponse(this.storeUseCase.getNaverBlogApiByStore(storeId, blogNum)));
     }
 }

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -107,7 +107,10 @@ public class StoreController {
     @Operation(description = "케이크샵 상세 정보 조회(상세 정보만)")
     @GetMapping("/{id}")
     public ResponseEntity<StoreDetailResponse> getStoreDetail(@PathVariable("id") Long storeId) {
-        return ResponseEntity.ok().body(this.storeUseCase.getStoreDetail(storeId));
+        StoreResponse storeResponse = this.storeUseCase.getStore(storeId);
+        return ResponseEntity.ok().body(
+                new StoreDetailResponse(storeResponse,
+                                        this.storeUseCase.getNaverLocalApiByStore(storeResponse)));
     }
 
     @Operation(description = "케이크샵 블로그 정보 조회")

--- a/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
@@ -76,7 +76,7 @@ public class StorePersistenceAdapter implements LoadStorePort, SaveStorePort, De
     }
 
     @Override
-    public Map<Long, StoreResponse> getStoreDetail(Long storeId) {
+    public Map<Long, StoreResponse> getStore(Long storeId) {
         return queryFactory
                 .select(store)
                 .from(store)

--- a/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
@@ -3,7 +3,7 @@ package prography.cakeke.server.store.application.port.in;
 import java.util.List;
 
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreBlogResponse;
+import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.domain.District;
@@ -28,7 +28,7 @@ public interface StoreUseCase {
 
     StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(StoreResponse storeResponse);
 
-    StoreBlogResponse getStoreBlog(Long storeId, Integer blogNum);
+    List<StoreNaverBlogSearchApiResponse> getNaverBlogApiByStore(Long storeId, Integer blogNum);
 
     Store getByName(String name);
 }

--- a/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
@@ -4,7 +4,8 @@ import java.util.List;
 
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreBlogResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreDetailResponse;
+import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
+import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.domain.District;
 import prography.cakeke.server.store.domain.Store;
 import prography.cakeke.server.store.domain.StoreTag;
@@ -23,7 +24,9 @@ public interface StoreUseCase {
 
     List<StoreTag> getStoreTypeByStoreId(Long storeId);
 
-    StoreDetailResponse getStoreDetail(Long storeId);
+    StoreResponse getStore(Long storeId);
+
+    StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(StoreResponse storeResponse);
 
     StoreBlogResponse getStoreBlog(Long storeId, Integer blogNum);
 

--- a/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
@@ -22,7 +22,7 @@ public interface LoadStorePort {
             Double southwestLatitude, Double northeastLatitude
     );
 
-    Map<Long, StoreResponse> getStoreDetail(Long storeId);
+    Map<Long, StoreResponse> getStore(Long storeId);
 
     Optional<Store> getByName(String name);
 

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreBlogResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreDetailResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
@@ -99,20 +98,16 @@ public class StoreService implements StoreUseCase {
         return loadStorePort.getStoreTagByStoreId(storeId);
     }
 
-    /**
-     * 가게 아이디를 받아 가게 상세정보를 반환합니다.
-     * @param storeId 가게 아이디
-     * @return 가게 상세정보
-     */
     @Override
-    public StoreDetailResponse getStoreDetail(Long storeId) {
-        StoreResponse storeResponse = loadStorePort.getStoreDetail(storeId).get(storeId);
+    public StoreResponse getStore(Long storeId) {
+        return loadStorePort.getStoreDetail(storeId).get(storeId);
+    }
+
+    @Override
+    public StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(StoreResponse storeResponse) {
         final String storeName = storeResponse.getName();
         // 네이버 지역 검색 api 결과값 리턴
-        StoreNaverLocalSearchApiResponse storeNaverLocalSearchApiResponse =
-                loadNaverSearchApiPort.getNaverLocalSearchResponse(storeName);
-        // 추가 정보 합쳐서 리턴
-        return new StoreDetailResponse(storeResponse, storeNaverLocalSearchApiResponse);
+        return loadNaverSearchApiPort.getNaverLocalSearchResponse(storeName);
     }
 
     /**

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -99,7 +99,7 @@ public class StoreService implements StoreUseCase {
 
     @Override
     public StoreResponse getStore(Long storeId) {
-        return loadStorePort.getStoreDetail(storeId).get(storeId);
+        return loadStorePort.getStore(storeId).get(storeId);
     }
 
     @Override
@@ -110,7 +110,7 @@ public class StoreService implements StoreUseCase {
 
     @Override
     public List<StoreNaverBlogSearchApiResponse> getNaverBlogApiByStore(Long storeId, Integer blogNum) {
-        StoreResponse storeResponse = loadStorePort.getStoreDetail(storeId).get(storeId);
+        StoreResponse storeResponse = loadStorePort.getStore(storeId).get(storeId);
         final String storeName = storeResponse.getName();
         return loadNaverSearchApiPort.getNaverBlogSearchResponse(storeName, blogNum);
     }

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreBlogResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
@@ -106,24 +105,14 @@ public class StoreService implements StoreUseCase {
     @Override
     public StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(StoreResponse storeResponse) {
         final String storeName = storeResponse.getName();
-        // 네이버 지역 검색 api 결과값 리턴
         return loadNaverSearchApiPort.getNaverLocalSearchResponse(storeName);
     }
 
-    /**
-     * 해당 가게의 네이버 블로그 정보를 반환합니다.
-     * @param storeId 가게 아이디
-     * @param blogNum 가져올 블로그 개수 (기본 값 3)
-     * @return 블로그 리스트
-     */
     @Override
-    public StoreBlogResponse getStoreBlog(Long storeId, Integer blogNum) {
+    public List<StoreNaverBlogSearchApiResponse> getNaverBlogApiByStore(Long storeId, Integer blogNum) {
         StoreResponse storeResponse = loadStorePort.getStoreDetail(storeId).get(storeId);
         final String storeName = storeResponse.getName();
-        // 네이버 블로그 검색 api 결과값 리턴
-        List<StoreNaverBlogSearchApiResponse> storeNaverBlogSearchApiResponseList =
-                loadNaverSearchApiPort.getNaverBlogSearchResponse(storeName, blogNum);
-        return new StoreBlogResponse(storeNaverBlogSearchApiResponseList);
+        return loadNaverSearchApiPort.getNaverBlogSearchResponse(storeName, blogNum);
     }
 
     /**

--- a/src/test/java/prography/cakeke/server/common/BaseMock.java
+++ b/src/test/java/prography/cakeke/server/common/BaseMock.java
@@ -14,7 +14,7 @@ import prography.cakeke.server.store.domain.StoreType;
 @SpringBootTest
 @Transactional
 @Rollback
-public class BaseTest {
+public class BaseMock {
     protected final City testCity = City.SEOUL;
     protected final District testDistrict = District.GANGNAM;
     protected final Double testLatitude = 37.5085138;

--- a/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
+++ b/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import prography.cakeke.server.common.BaseTest;
+import prography.cakeke.server.common.BaseMock;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
@@ -24,7 +24,7 @@ import prography.cakeke.server.store.domain.StoreAndTag;
 import prography.cakeke.server.store.domain.StoreTag;
 import prography.cakeke.server.store.domain.StoreType;
 
-class StoreServiceTest extends BaseTest {
+class StoreServiceTest extends BaseMock {
     @Autowired
     protected StoreService storeService;
     @Autowired

--- a/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
+++ b/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
@@ -13,7 +13,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import prography.cakeke.server.common.BaseTest;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreBlogResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreDetailResponse;
+import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
+import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.adapter.out.persistence.StoreAndTagRepository;
 import prography.cakeke.server.store.adapter.out.persistence.StoreRepository;
 import prography.cakeke.server.store.adapter.out.persistence.StoreTagRepository;
@@ -122,12 +123,29 @@ class StoreServiceTest extends BaseTest {
     }
 
     @Test
-    @DisplayName("가게 상세정보 + 네이버 검색 테스트(성공)")
-    public void getStoreDetailTestSuccess() {
-        Long testStoreId = storeRepository.findByName(testNaverStoreName).get().getId();
-        StoreDetailResponse testStoreDetailResponse = storeService.getStoreDetail(testStoreId);
+    @DisplayName("가게 조회(성공)")
+    public void getStoreByStoreIdTestSuccess() {
+        Long testStoreId = storeRepository.findByName(testName).get().getId();
+        StoreResponse testStoreResponse = storeService.getStore(testStoreId);
 
-        assertThat(testStoreDetailResponse.getAddress()).isEqualTo(testNaverStoreAddress);
+        assertThat(testStoreResponse.getCity()).isEqualTo(testCity);
+        assertThat(testStoreResponse.getDistrict()).isEqualTo(testDistrict);
+        assertThat(testStoreResponse.getLatitude()).isEqualTo(testLatitude);
+        assertThat(testStoreResponse.getLocation()).isEqualTo(testLocation);
+        assertThat(testStoreResponse.getLongitude()).isEqualTo(testLongitude);
+        assertThat(testStoreResponse.getName()).isEqualTo(testName);
+        assertThat(testStoreResponse.getShareLink()).isEqualTo(testShareLink);
+    }
+
+    @Test
+    @DisplayName("네이버 로컬 API 조회 테스트(성공)")
+    public void getNaverLocalApiTestSuccess() {
+        Long testStoreId = storeRepository.findByName(testNaverStoreName).get().getId();
+        StoreResponse testStoreResponse = storeService.getStore(testStoreId);
+        StoreNaverLocalSearchApiResponse testStoreNaverLocalSearchApiResponse =
+                storeService.getNaverLocalApiByStore(testStoreResponse);
+
+        assertThat(testStoreNaverLocalSearchApiResponse.getAddress()).isEqualTo(testNaverStoreAddress);
     }
 
     @Test

--- a/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
+++ b/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import prography.cakeke.server.common.BaseTest;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreBlogResponse;
+import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.adapter.out.persistence.StoreAndTagRepository;
@@ -149,12 +149,13 @@ class StoreServiceTest extends BaseTest {
     }
 
     @Test
-    @DisplayName("가게 네이버 블로그 테스트(성공)")
-    public void getStoreBlogTestSuccess() {
+    @DisplayName("가게 네이버 블로그 조회 테스트(성공)")
+    public void getNaverBlogApiTestSuccess() {
         Long testStoreId = storeRepository.findByName(testNaverStoreName).get().getId();
-        StoreBlogResponse testStoreBlogResponse = storeService.getStoreBlog(testStoreId, 2);
+        List<StoreNaverBlogSearchApiResponse> testStoreNaverBlogSearchApiResponseList =
+                storeService.getNaverBlogApiByStore(testStoreId, 2);
 
-        assertThat(testStoreBlogResponse.getBlogPosts()).hasSize(2);
+        assertThat(testStoreNaverBlogSearchApiResponseList).hasSize(2);
     }
 
     @Test


### PR DESCRIPTION
### Refactor/store
- store 서비스 new 코드 컨트롤러로 이동했어요.
- 관련 테스트 코드를 수정했어요.

### Style/store
- BaseTest라는 네이밍에 맞지 않아 기본적으로 Mocking을 해주는 의미로 BaseMock으로 이름을 변경했어요.