### PR TITLE
refactor(store): district 별로 가게 갯수 조회시, querydsl에서 response를 조회하지 않도록 변경

### DIFF
--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
-import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
+import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.FeedImageResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreBlogResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreDetailResponse;
@@ -31,7 +31,7 @@ public class StoreController {
 
     @Operation(description = "각 구별 가게 갯수 조회")
     @GetMapping("/district/count")
-    public ResponseEntity<List<DistrictCountResponse>> getCount() {
+    public ResponseEntity<List<DistrictCountDTO>> getCount() {
         return ResponseEntity.ok().body(this.storeUseCase.getCount());
     }
 

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/response/DistrictCountDTO.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/response/DistrictCountDTO.java
@@ -6,7 +6,7 @@ import prography.cakeke.server.store.domain.District;
 
 @Getter
 @NoArgsConstructor
-public class DistrictCountResponse {
+public class DistrictCountDTO {
 
     District district;
 

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/response/StoreNaverLocalSearchApiResponse.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/response/StoreNaverLocalSearchApiResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 public class StoreNaverLocalSearchApiResponse {
     String link; // 가게 URL
-
+    
     String description; // 가게 설명
 
     String phoneNumber; // 가게 번호

--- a/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
@@ -1,7 +1,6 @@
 package prography.cakeke.server.store.adapter.out.persistence;
 
 import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.list;
 
 import java.util.List;
 import java.util.Map;
@@ -16,7 +15,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
-import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
+import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.application.port.out.DeleteStorePort;
 import prography.cakeke.server.store.application.port.out.LoadStorePort;
@@ -43,9 +42,9 @@ public class StorePersistenceAdapter implements LoadStorePort, SaveStorePort, De
     private final QStoreTag storeTag = QStoreTag.storeTag;
 
     @Override
-    public List<DistrictCountResponse> getDistrictCount() {
+    public List<DistrictCountDTO> getDistrictCount() {
         return queryFactory
-                .select(Projections.fields(DistrictCountResponse.class,
+                .select(Projections.fields(DistrictCountDTO.class,
                                            store.district,
                                            store.id.count().as("count")
                 ))

--- a/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
@@ -2,7 +2,7 @@ package prography.cakeke.server.store.application.port.in;
 
 import java.util.List;
 
-import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
+import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
@@ -12,7 +12,7 @@ import prography.cakeke.server.store.domain.StoreTag;
 import prography.cakeke.server.store.domain.StoreType;
 
 public interface StoreUseCase {
-    List<DistrictCountResponse> getCount();
+    List<DistrictCountDTO> getCount();
 
     List<Store> getList(List<District> district, List<StoreType> storeTypes, int page);
 

--- a/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 
-import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
+import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.domain.District;
 import prography.cakeke.server.store.domain.Store;
@@ -14,7 +14,7 @@ import prography.cakeke.server.store.domain.StoreTag;
 import prography.cakeke.server.store.domain.StoreType;
 
 public interface LoadStorePort {
-    List<DistrictCountResponse> getDistrictCount();
+    List<DistrictCountDTO> getDistrictCount();
 
     List<Store> getList(
             List<District> district, List<StoreType> storeTypes, Pageable pageable,

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
-import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
+import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
@@ -39,7 +39,7 @@ public class StoreService implements StoreUseCase {
      * @return 각 구별 가게의 개수
      */
     @Override
-    public List<DistrictCountResponse> getCount() {
+    public List<DistrictCountDTO> getCount() {
         return loadStorePort.getDistrictCount();
     }
 


### PR DESCRIPTION
### Refactor/store
- district 별로 가게 갯수 조회시, querydsl에서 response를 조회하지 않도록 변경했어요.

querydsl에서 조회하는 데이터 타입은 Tuple 또는 DTO 또는 Entity입니다.
그동안은 reponse DTO를 사용했지만 response와 persistece adapter가 의존성을 갖는 것은 안 된다고 생각하여 DTO로 변경하였습니다.
하지만 조회되는 데이터인 DTO와 reponse의 차이가 없기 때문에 현재는 파일을 축소하고자 DTO를 controller에서 그대로 반환합니다.