### PR TITLE
refactor(store): feed 조회 api를 완전 랜덤으로 변경 #53

### DIFF
--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -1,5 +1,6 @@
 package prography.cakeke.server.store.adapter.in.web;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -80,27 +81,21 @@ public class StoreController {
     @Operation(description = "feed로 케이크 이미지 조회")
     @GetMapping("/feed")
     public ResponseEntity<List<FeedImageResponse>> getFeedImage(
-            @RequestParam(value = "page", required = false, defaultValue = "1") int page,
-            @RequestParam(value = "southwestLatitude", required = true) Double southwestLatitude,
-            @RequestParam(value = "southwestLongitude", required = true) Double southwestLongitude,
-            @RequestParam(value = "northeastLatitude", required = true) Double northeastLatitude,
-            @RequestParam(value = "northeastLongitude", required = true) Double northeastLongitude
+            @RequestParam(value = "page", required = false, defaultValue = "1") int page
     ) {
-        List<Store> stores = this.storeUseCase.reload(
-                null, page,
-                southwestLatitude, southwestLongitude,
-                northeastLatitude, northeastLongitude
-        );
+        List<Store> stores = this.storeUseCase.getList(null, null, page);
 
         List<FeedImageResponse> response = stores
                 .stream().flatMap(
                         store -> store.getImageUrls()
                                       .stream().map(
-                                        imageUrl -> new FeedImageResponse(store.getId(), imageUrl)
+                                        imageUrl -> new FeedImageResponse(
+                                                store.getId(), store.getName(), store.getDistrict(), imageUrl)
                                 )
                 )
                 .collect(Collectors.toList());
-
+        
+        Collections.shuffle(response);
         return ResponseEntity.ok().body(response);
     }
 

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/response/FeedImageResponse.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/response/FeedImageResponse.java
@@ -2,17 +2,24 @@ package prography.cakeke.server.store.adapter.in.web.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import prography.cakeke.server.store.domain.District;
 
 @Getter
 public class FeedImageResponse {
 
     Long storeId;
 
+    String storeName;
+
+    District district;
+
     String imageUrl;
 
     @Builder
-    public FeedImageResponse(Long storeId, String imageUrl) {
+    public FeedImageResponse(Long storeId, String storeName, District district, String imageUrl) {
         this.storeId = storeId;
+        this.storeName = storeName;
+        this.district = district;
         this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
@@ -1,7 +1,6 @@
 package prography.cakeke.server.store.adapter.out.persistence;
 
 import static com.querydsl.core.group.GroupBy.groupBy;
-import static com.querydsl.core.group.GroupBy.list;
 
 import java.util.List;
 import java.util.Map;
@@ -71,7 +70,6 @@ public class StorePersistenceAdapter implements LoadStorePort, SaveStorePort, De
                 .distinct()
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
-                .orderBy(store.id.asc())
                 .fetch();
     }
 


### PR DESCRIPTION
### Refactor/store
- feed 이미지 조회 api에서 화면 위도, 경도 없이 완전 랜덤하게 사진 제공하도록 변경했어요.
- response에는 케이크샵 이름, district, 케이크샵 id 반환하도록 했어요.