### PR TITLE
refactor(store): StoreResponse Store로 변경

### DIFF
--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -107,10 +107,10 @@ public class StoreController {
     @Operation(description = "케이크샵 상세 정보 조회(상세 정보만)")
     @GetMapping("/{id}")
     public ResponseEntity<StoreDetailResponse> getStoreDetail(@PathVariable("id") Long storeId) {
-        StoreResponse storeResponse = this.storeUseCase.getStore(storeId);
+        Store store = this.storeUseCase.getStore(storeId);
         return ResponseEntity.ok().body(
-                new StoreDetailResponse(storeResponse,
-                                        this.storeUseCase.getNaverLocalApiByStore(storeResponse)));
+                new StoreDetailResponse(store,
+                                        this.storeUseCase.getNaverLocalApiByStore(store)));
     }
 
     @Operation(description = "케이크샵 블로그 정보 조회")

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -55,10 +55,10 @@ public class StoreController {
     public ResponseEntity<List<StoreResponse>> reload(
             @RequestParam(value = "storeTypes", required = false) List<StoreType> storeTypes,
             @RequestParam(value = "page", required = false, defaultValue = "1") int page,
-            @RequestParam(value = "southwestLatitude", required = true) Double southwestLatitude,
-            @RequestParam(value = "southwestLongitude", required = true) Double southwestLongitude,
-            @RequestParam(value = "northeastLatitude", required = true) Double northeastLatitude,
-            @RequestParam(value = "northeastLongitude", required = true) Double northeastLongitude
+            @RequestParam(value = "southwestLatitude") Double southwestLatitude,
+            @RequestParam(value = "southwestLongitude") Double southwestLongitude,
+            @RequestParam(value = "northeastLatitude") Double northeastLatitude,
+            @RequestParam(value = "northeastLongitude") Double northeastLongitude
     ) {
         return ResponseEntity.ok().body(
                 this.storeUseCase.reload(
@@ -94,7 +94,7 @@ public class StoreController {
                                 )
                 )
                 .collect(Collectors.toList());
-        
+
         Collections.shuffle(response);
         return ResponseEntity.ok().body(response);
     }
@@ -102,10 +102,10 @@ public class StoreController {
     @Operation(description = "케이크샵 상세 정보 조회(상세 정보만)")
     @GetMapping("/{id}")
     public ResponseEntity<StoreDetailResponse> getStoreDetail(@PathVariable("id") Long storeId) {
-        StoreResponse storeResponse = this.storeUseCase.getStore(storeId);
+        Store store = this.storeUseCase.getStore(storeId);
         return ResponseEntity.ok().body(
-                new StoreDetailResponse(storeResponse,
-                                        this.storeUseCase.getNaverLocalApiByStore(storeResponse)));
+                new StoreDetailResponse(store,
+                                        this.storeUseCase.getNaverLocalApiByStore(store)));
     }
 
     @Operation(description = "케이크샵 블로그 정보 조회")

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/StoreController.java
@@ -54,10 +54,10 @@ public class StoreController {
     public ResponseEntity<List<StoreResponse>> reload(
             @RequestParam(value = "storeTypes", required = false) List<StoreType> storeTypes,
             @RequestParam(value = "page", required = false, defaultValue = "1") int page,
-            @RequestParam(value = "southwestLatitude", required = true) Double southwestLatitude,
-            @RequestParam(value = "southwestLongitude", required = true) Double southwestLongitude,
-            @RequestParam(value = "northeastLatitude", required = true) Double northeastLatitude,
-            @RequestParam(value = "northeastLongitude", required = true) Double northeastLongitude
+            @RequestParam(value = "southwestLatitude") Double southwestLatitude,
+            @RequestParam(value = "southwestLongitude") Double southwestLongitude,
+            @RequestParam(value = "northeastLatitude") Double northeastLatitude,
+            @RequestParam(value = "northeastLongitude") Double northeastLongitude
     ) {
         return ResponseEntity.ok().body(
                 this.storeUseCase.reload(
@@ -81,10 +81,10 @@ public class StoreController {
     @GetMapping("/feed")
     public ResponseEntity<List<FeedImageResponse>> getFeedImage(
             @RequestParam(value = "page", required = false, defaultValue = "1") int page,
-            @RequestParam(value = "southwestLatitude", required = true) Double southwestLatitude,
-            @RequestParam(value = "southwestLongitude", required = true) Double southwestLongitude,
-            @RequestParam(value = "northeastLatitude", required = true) Double northeastLatitude,
-            @RequestParam(value = "northeastLongitude", required = true) Double northeastLongitude
+            @RequestParam(value = "southwestLatitude") Double southwestLatitude,
+            @RequestParam(value = "southwestLongitude") Double southwestLongitude,
+            @RequestParam(value = "northeastLatitude") Double northeastLatitude,
+            @RequestParam(value = "northeastLongitude") Double northeastLongitude
     ) {
         List<Store> stores = this.storeUseCase.reload(
                 null, page,

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/response/StoreDetailResponse.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/response/StoreDetailResponse.java
@@ -2,12 +2,16 @@ package prography.cakeke.server.store.adapter.in.web.response;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import prography.cakeke.server.store.domain.City;
 import prography.cakeke.server.store.domain.District;
+import prography.cakeke.server.store.domain.Store;
+import prography.cakeke.server.store.domain.StoreAndTag;
+import prography.cakeke.server.store.domain.StoreTag;
 import prography.cakeke.server.store.domain.StoreType;
 
 @Getter
@@ -49,21 +53,25 @@ public class StoreDetailResponse {
 
     @Builder
     public StoreDetailResponse(
-            StoreResponse storeResponse, StoreNaverLocalSearchApiResponse storeNaverLocalSearchApiResponse
+            Store store, StoreNaverLocalSearchApiResponse storeNaverLocalSearchApiResponse
     ) {
-        this.id = storeResponse.getId();
-        this.createdAt = storeResponse.getCreatedAt();
-        this.modifiedAt = storeResponse.getModifiedAt();
-        this.name = storeResponse.getName();
-        this.shareLink = storeResponse.getShareLink();
-        this.city = storeResponse.getCity();
-        this.district = storeResponse.getDistrict();
-        this.location = storeResponse.getLocation();
-        this.latitude = storeResponse.getLatitude();
-        this.longitude = storeResponse.getLongitude();
-        this.storeTypes = storeResponse.getStoreTypes();
-        this.thumbnail = storeResponse.getThumbnail();
-        this.imageUrls = storeResponse.getImageUrls();
+        List<StoreTag> storeTagList = store.getStoreAndTags().stream().map(StoreAndTag::getStoreTag).toList();
+
+        this.id = store.getId();
+        this.createdAt = store.getCreatedAt();
+        this.modifiedAt = store.getModifiedAt();
+        this.name = store.getName();
+        this.shareLink = store.getShareLink();
+        this.city = store.getCity();
+        this.district = store.getDistrict();
+        this.location = store.getLocation();
+        this.latitude = store.getLatitude();
+        this.longitude = store.getLongitude();
+        this.storeTypes = storeTagList != null ?
+                          storeTagList.stream().map(StoreTag::getStoreType).collect(Collectors.toList())
+                                               : List.of();
+        this.thumbnail = store.getThumbnail();
+        this.imageUrls = store.getImageUrls();
         this.link = storeNaverLocalSearchApiResponse.getLink();
         this.description = storeNaverLocalSearchApiResponse.getDescription();
         this.phoneNumber = storeNaverLocalSearchApiResponse.getPhoneNumber();

--- a/src/main/java/prography/cakeke/server/store/adapter/in/web/response/StoreDetailResponse.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/in/web/response/StoreDetailResponse.java
@@ -56,7 +56,9 @@ public class StoreDetailResponse {
             Store store, StoreNaverLocalSearchApiResponse storeNaverLocalSearchApiResponse
     ) {
         List<StoreTag> storeTagList = store.getStoreAndTags().stream().map(StoreAndTag::getStoreTag).toList();
-
+        this.storeTypes = storeTagList != null ?
+                          storeTagList.stream().map(StoreTag::getStoreType).collect(Collectors.toList())
+                                               : List.of();
         this.id = store.getId();
         this.createdAt = store.getCreatedAt();
         this.modifiedAt = store.getModifiedAt();
@@ -67,9 +69,6 @@ public class StoreDetailResponse {
         this.location = store.getLocation();
         this.latitude = store.getLatitude();
         this.longitude = store.getLongitude();
-        this.storeTypes = storeTagList != null ?
-                          storeTagList.stream().map(StoreTag::getStoreType).collect(Collectors.toList())
-                                               : List.of();
         this.thumbnail = store.getThumbnail();
         this.imageUrls = store.getImageUrls();
         this.link = storeNaverLocalSearchApiResponse.getLink();

--- a/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
+++ b/src/main/java/prography/cakeke/server/store/adapter/out/persistence/StorePersistenceAdapter.java
@@ -1,9 +1,6 @@
 package prography.cakeke.server.store.adapter.out.persistence;
 
-import static com.querydsl.core.group.GroupBy.groupBy;
-
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
@@ -16,7 +13,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
-import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.application.port.out.DeleteStorePort;
 import prography.cakeke.server.store.application.port.out.LoadStorePort;
 import prography.cakeke.server.store.application.port.out.SaveStorePort;
@@ -75,21 +71,13 @@ public class StorePersistenceAdapter implements LoadStorePort, SaveStorePort, De
     }
 
     @Override
-    public Map<Long, StoreResponse> getStore(Long storeId) {
+    public Store getStore(Long storeId) {
         return queryFactory
-                .select(store)
-                .from(store)
+                .selectFrom(store)
                 .leftJoin(store.storeAndTags, storeAndTag)
                 .leftJoin(storeAndTag.storeTag, storeTag)
                 .where(store.id.eq(storeId))
-                .transform(
-                        groupBy(store.id).as(
-                                Projections.constructor(StoreResponse.class,
-                                                        store,
-                                                        list(storeTag)
-                                )
-                        )
-                );
+                .fetchOne();
     }
 
     @Override

--- a/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/in/StoreUseCase.java
@@ -5,7 +5,6 @@ import java.util.List;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.domain.District;
 import prography.cakeke.server.store.domain.Store;
 import prography.cakeke.server.store.domain.StoreTag;
@@ -24,9 +23,9 @@ public interface StoreUseCase {
 
     List<StoreTag> getStoreTypeByStoreId(Long storeId);
 
-    StoreResponse getStore(Long storeId);
+    Store getStore(Long storeId);
 
-    StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(StoreResponse storeResponse);
+    StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(Store store);
 
     List<StoreNaverBlogSearchApiResponse> getNaverBlogApiByStore(Long storeId, Integer blogNum);
 

--- a/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
+++ b/src/main/java/prography/cakeke/server/store/application/port/out/LoadStorePort.java
@@ -1,13 +1,11 @@
 package prography.cakeke.server.store.application.port.out;
 
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
-import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.domain.District;
 import prography.cakeke.server.store.domain.Store;
 import prography.cakeke.server.store.domain.StoreTag;
@@ -22,7 +20,7 @@ public interface LoadStorePort {
             Double southwestLatitude, Double northeastLatitude
     );
 
-    Map<Long, StoreResponse> getStore(Long storeId);
+    Store getStore(Long storeId);
 
     Optional<Store> getByName(String name);
 

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -97,17 +97,32 @@ public class StoreService implements StoreUseCase {
         return loadStorePort.getStoreTagByStoreId(storeId);
     }
 
+    /**
+     * 가게 아이디를 받아 가게 정보를 반환합니다.
+     * @param storeId 가게 아이디
+     * @return 가게 정보
+     */
     @Override
     public StoreResponse getStore(Long storeId) {
         return loadStorePort.getStore(storeId).get(storeId);
     }
 
+    /**
+     * 가게 정보를 받아 해당 가게의 네이버 지역 검색 결과를 반환합니다.
+     * @param store 가게
+     * @return 네이버 지역 검색 결과
+     */
     @Override
     public StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(StoreResponse storeResponse) {
         final String storeName = storeResponse.getName();
         return loadNaverSearchApiPort.getNaverLocalSearchResponse(storeName);
     }
 
+    /**
+     * 가게 Id와 원하는 블로그 개수를 받아 해당 가게의 네이버 블로그 검색 결과를 반환합니다.
+     * @param storeId 가게 Id, blogNum 보여줄 블로그 개수
+     * @return 네이버 블로그 검색 결과
+     */
     @Override
     public List<StoreNaverBlogSearchApiResponse> getNaverBlogApiByStore(Long storeId, Integer blogNum) {
         StoreResponse storeResponse = loadStorePort.getStore(storeId).get(storeId);

--- a/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
+++ b/src/main/java/prography/cakeke/server/store/application/service/StoreService.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.application.port.in.StoreUseCase;
 import prography.cakeke.server.store.application.port.out.LoadNaverSearchApiPort;
 import prography.cakeke.server.store.application.port.out.LoadStorePort;
@@ -103,8 +102,8 @@ public class StoreService implements StoreUseCase {
      * @return 가게 정보
      */
     @Override
-    public StoreResponse getStore(Long storeId) {
-        return loadStorePort.getStore(storeId).get(storeId);
+    public Store getStore(Long storeId) {
+        return loadStorePort.getStore(storeId);
     }
 
     /**
@@ -113,8 +112,8 @@ public class StoreService implements StoreUseCase {
      * @return 네이버 지역 검색 결과
      */
     @Override
-    public StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(StoreResponse storeResponse) {
-        final String storeName = storeResponse.getName();
+    public StoreNaverLocalSearchApiResponse getNaverLocalApiByStore(Store store) {
+        final String storeName = store.getName();
         return loadNaverSearchApiPort.getNaverLocalSearchResponse(storeName);
     }
 
@@ -125,8 +124,8 @@ public class StoreService implements StoreUseCase {
      */
     @Override
     public List<StoreNaverBlogSearchApiResponse> getNaverBlogApiByStore(Long storeId, Integer blogNum) {
-        StoreResponse storeResponse = loadStorePort.getStore(storeId).get(storeId);
-        final String storeName = storeResponse.getName();
+        Store store = loadStorePort.getStore(storeId);
+        final String storeName = store.getName();
         return loadNaverSearchApiPort.getNaverBlogSearchResponse(storeName, blogNum);
     }
 

--- a/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
+++ b/src/test/java/prography/cakeke/server/store/application/service/StoreServiceTest.java
@@ -11,10 +11,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import prography.cakeke.server.common.BaseMock;
-import prography.cakeke.server.store.adapter.in.web.response.DistrictCountResponse;
+import prography.cakeke.server.store.adapter.in.web.response.DistrictCountDTO;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverBlogSearchApiResponse;
 import prography.cakeke.server.store.adapter.in.web.response.StoreNaverLocalSearchApiResponse;
-import prography.cakeke.server.store.adapter.in.web.response.StoreResponse;
 import prography.cakeke.server.store.adapter.out.persistence.StoreAndTagRepository;
 import prography.cakeke.server.store.adapter.out.persistence.StoreRepository;
 import prography.cakeke.server.store.adapter.out.persistence.StoreTagRepository;
@@ -62,7 +61,7 @@ class StoreServiceTest extends BaseMock {
     @Test
     @DisplayName("각 구의 개수 반환(성공)")
     public void getCountTestSuccess() {
-        List<DistrictCountResponse> districtCountResponseList = storeService.getCount();
+        List<DistrictCountDTO> districtCountResponseList = storeService.getCount();
         assertThat((long) districtCountResponseList.size()).isEqualTo(1L);
     }
 
@@ -126,24 +125,24 @@ class StoreServiceTest extends BaseMock {
     @DisplayName("가게 조회(성공)")
     public void getStoreByStoreIdTestSuccess() {
         Long testStoreId = storeRepository.findByName(testName).get().getId();
-        StoreResponse testStoreResponse = storeService.getStore(testStoreId);
+        Store testStore = storeService.getStore(testStoreId);
 
-        assertThat(testStoreResponse.getCity()).isEqualTo(testCity);
-        assertThat(testStoreResponse.getDistrict()).isEqualTo(testDistrict);
-        assertThat(testStoreResponse.getLatitude()).isEqualTo(testLatitude);
-        assertThat(testStoreResponse.getLocation()).isEqualTo(testLocation);
-        assertThat(testStoreResponse.getLongitude()).isEqualTo(testLongitude);
-        assertThat(testStoreResponse.getName()).isEqualTo(testName);
-        assertThat(testStoreResponse.getShareLink()).isEqualTo(testShareLink);
+        assertThat(testStore.getCity()).isEqualTo(testCity);
+        assertThat(testStore.getDistrict()).isEqualTo(testDistrict);
+        assertThat(testStore.getLatitude()).isEqualTo(testLatitude);
+        assertThat(testStore.getLocation()).isEqualTo(testLocation);
+        assertThat(testStore.getLongitude()).isEqualTo(testLongitude);
+        assertThat(testStore.getName()).isEqualTo(testName);
+        assertThat(testStore.getShareLink()).isEqualTo(testShareLink);
     }
 
     @Test
     @DisplayName("네이버 로컬 API 조회 테스트(성공)")
     public void getNaverLocalApiTestSuccess() {
         Long testStoreId = storeRepository.findByName(testNaverStoreName).get().getId();
-        StoreResponse testStoreResponse = storeService.getStore(testStoreId);
+        Store testStore = storeService.getStore(testStoreId);
         StoreNaverLocalSearchApiResponse testStoreNaverLocalSearchApiResponse =
-                storeService.getNaverLocalApiByStore(testStoreResponse);
+                storeService.getNaverLocalApiByStore(testStore);
 
         assertThat(testStoreNaverLocalSearchApiResponse.getAddress()).isEqualTo(testNaverStoreAddress);
     }


### PR DESCRIPTION
### Refactor/store
- 기존 컨트롤러가 아닌 곳에서 StoreResponse로 리턴되던 메소드를 Store로 변경하도록 수정했어요.
- DistrictCountDTO 변경 부분을 테스트에도 적용했어요.
- getStore의 리턴 타입을 변경했어요.
- 불필요한 매개변수를 제거했어요.